### PR TITLE
fix(env): preserve single-quote literal intent in shell output

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Children inherit all parent variables and can override them.
   └────────────────────────────────────────────┘
 ```
 
+**Quoting** — rsenv preserves the source's quote style, matching shell semantics:
+
+```
+  export PW='p@$$w0rd'      ◄ single quotes → emitted literal (no expansion)
+  export DIR="$HOME/bin"    ◄ double quotes → $HOME expands when sourced
+```
+
+Store secrets that contain `$`, backticks, or other shell metacharacters in
+**single quotes** so they survive sourcing verbatim.
+
 **Key commands**:
 - `rsenv env tree` — visualize the hierarchy
 - `rsenv env select` — fuzzy-pick an env, write to `.envrc`

--- a/rsenv/src/application/services/environment.rs
+++ b/rsenv/src/application/services/environment.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles building merged environment variables from hierarchical env files.
 
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -18,6 +18,9 @@ use crate::infrastructure::traits::FileSystem;
 pub struct EnvOutput {
     /// Merged environment variables (parents overridden by children)
     pub variables: BTreeMap<String, String>,
+    /// Keys to emit as shell literals (single-quoted in source). Merged with
+    /// the same child-overrides-parent precedence as `variables`.
+    pub literal_keys: BTreeSet<String>,
     /// Files in the hierarchy, in BFS order (roots first)
     pub files: Vec<EnvFile>,
 }
@@ -55,13 +58,24 @@ impl EnvironmentService {
 
         // Merge variables: iterate in reverse (roots first) so children override
         let mut variables = BTreeMap::new();
+        let mut literal_keys = BTreeSet::new();
         for file in files.iter().rev() {
             for (key, value) in &file.variables {
                 variables.insert(key.clone(), value.clone());
+                // The redefining file also decides the quote style for this key.
+                if file.literal_keys.contains(key) {
+                    literal_keys.insert(key.clone());
+                } else {
+                    literal_keys.remove(key);
+                }
             }
         }
 
-        Ok(EnvOutput { variables, files })
+        Ok(EnvOutput {
+            variables,
+            literal_keys,
+            files,
+        })
     }
 
     /// Collect all files in the hierarchy via BFS traversal.

--- a/rsenv/src/domain/entities.rs
+++ b/rsenv/src/domain/entities.rs
@@ -1,6 +1,6 @@
 //! Domain entities: core data structures
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 /// A project linked to a vault.
@@ -30,6 +30,10 @@ pub struct EnvFile {
     pub parents: Vec<PathBuf>,
     /// Parsed environment variables
     pub variables: BTreeMap<String, String>,
+    /// Keys whose source value was single-quoted and must be emitted as a
+    /// literal (no shell expansion). Keys absent here keep the legacy
+    /// double-quoted/unquoted behavior (expansion preserved).
+    pub literal_keys: BTreeSet<String>,
 }
 
 impl EnvFile {
@@ -45,6 +49,7 @@ impl EnvFile {
     pub fn parse(content: &str, file_path: PathBuf) -> Result<Self, EnvFileParseError> {
         let mut parents = Vec::new();
         let mut variables = BTreeMap::new();
+        let mut literal_keys = BTreeSet::new();
 
         let parent_dir = file_path.parent();
 
@@ -86,7 +91,10 @@ impl EnvFile {
 
             // v1 compatibility: only parse "export VAR=value" lines
             if let Some(rest) = trimmed.strip_prefix("export ") {
-                if let Some((key, value)) = parse_env_line(rest) {
+                if let Some((key, value, single_quoted)) = parse_env_line(rest) {
+                    if single_quoted {
+                        literal_keys.insert(key.to_string());
+                    }
                     variables.insert(key.to_string(), value);
                 }
             }
@@ -96,24 +104,36 @@ impl EnvFile {
             path: file_path,
             parents,
             variables,
+            literal_keys,
         })
     }
 }
 
 /// Parse a single environment variable line.
-/// Returns (key, value) with trailing comments and quotes stripped from value.
-fn parse_env_line(line: &str) -> Option<(&str, String)> {
+/// Returns (key, value, single_quoted) with trailing comments and quotes
+/// stripped from value. `single_quoted` records whether the source value was
+/// wrapped in single quotes (literal intent) so the writer can reproduce it.
+fn parse_env_line(line: &str) -> Option<(&str, String, bool)> {
     let eq_pos = line.find('=')?;
     let key = line[..eq_pos].trim();
     let value = line[eq_pos + 1..].trim();
 
-    // Strip trailing comment (outside quotes) before stripping quotes
+    // Strip trailing comment (outside quotes) before inspecting/stripping quotes
     let value = strip_trailing_comment(value);
+
+    // Record quote style before stripping (single quote = literal, no expansion)
+    let single_quoted = is_single_quoted(value);
 
     // Strip surrounding quotes
     let value = strip_quotes(value);
 
-    Some((key, value))
+    Some((key, value, single_quoted))
+}
+
+/// Whether a (comment-stripped) value is wrapped in single quotes.
+fn is_single_quoted(s: &str) -> bool {
+    let s = s.trim();
+    s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'')
 }
 
 /// Strip trailing comment from a value, respecting quotes.
@@ -257,8 +277,15 @@ pub struct StaleFile {
 }
 
 /// Quote a value for shell export if it contains spaces or special characters.
-/// Returns the value wrapped in double quotes if needed.
-pub fn shell_quote(value: &str) -> String {
+///
+/// `literal` selects the quoting strategy, mirroring the source's intent:
+/// - `false` (value was double-quoted or unquoted): wrap in double quotes,
+///   leaving `$`, backticks etc. for the shell to expand on source. Legacy
+///   behavior.
+/// - `true` (value was single-quoted): wrap in POSIX single quotes so the
+///   shell treats the value as a literal — no expansion, no command
+///   substitution. An embedded single quote becomes `'\''`.
+pub fn shell_quote(value: &str, literal: bool) -> String {
     // Characters that require quoting
     let needs_quoting = value.is_empty()
         || value.contains(|c: char| c.is_whitespace() || "\"'`$\\!;&|()<>".contains(c));
@@ -267,5 +294,9 @@ pub fn shell_quote(value: &str) -> String {
         return value.to_string();
     }
 
-    format!("\"{}\"", value)
+    if literal {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    } else {
+        format!("\"{}\"", value)
+    }
 }

--- a/rsenv/src/main.rs
+++ b/rsenv/src/main.rs
@@ -109,7 +109,8 @@ fn handle_env(
 
             // Output as shell-sourceable format
             for (key, value) in &result.variables {
-                println!("export {}={}", key, shell_quote(value));
+                let literal = result.literal_keys.contains(key);
+                println!("export {}={}", key, shell_quote(value, literal));
             }
             Ok(())
         }
@@ -122,7 +123,8 @@ fn handle_env(
 
             let mut exports = String::new();
             for (k, v) in &output.variables {
-                exports.push_str(&format!("export {}={}\n", k, shell_quote(v)));
+                let literal = output.literal_keys.contains(k);
+                exports.push_str(&format!("export {}={}\n", k, shell_quote(v, literal)));
             }
 
             update_vars_section(&fs, &envrc_path, &exports).map_err(|e| {
@@ -234,7 +236,8 @@ fn handle_env(
 
                     // Output as shell-sourceable format
                     for (key, value) in &result.variables {
-                        println!("export {}={}", key, shell_quote(value));
+                        let literal = result.literal_keys.contains(key);
+                        println!("export {}={}", key, shell_quote(value, literal));
                     }
                 }
                 None => {

--- a/rsenv/tests/env_file_test.rs
+++ b/rsenv/tests/env_file_test.rs
@@ -251,98 +251,161 @@ fn given_unquoted_value_with_trailing_comment_when_parsing_then_comment_stripped
     assert_eq!(env_file.variables.get("PORT"), Some(&"8080".to_string()));
 }
 
-// --- shell_quote tests ---
+// --- shell_quote tests (expansion mode: literal = false) ---
+// literal = false reproduces the legacy double-quote behavior used for values
+// that were double-quoted or unquoted in the source (shell expansion preserved).
 
 #[test]
 fn given_value_with_spaces_when_shell_quoting_then_adds_quotes() {
     assert_eq!(
-        shell_quote("--reverse --height 100%"),
+        shell_quote("--reverse --height 100%", false),
         "\"--reverse --height 100%\""
     );
 }
 
 #[test]
 fn given_simple_value_when_shell_quoting_then_no_quotes() {
-    assert_eq!(shell_quote("simple"), "simple");
-}
-
-#[test]
-fn given_value_with_embedded_quote_when_shell_quoting_then_wraps() {
-    assert_eq!(shell_quote("say \"hello\""), "\"say \"hello\"\"");
+    assert_eq!(shell_quote("simple", false), "simple");
 }
 
 #[test]
 fn given_empty_value_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote(""), "\"\"");
+    assert_eq!(shell_quote("", false), "\"\"");
 }
 
 #[test]
 fn given_value_with_dollar_when_shell_quoting_then_preserves_for_expansion() {
-    // $ is NOT escaped - allows shell variable expansion
-    assert_eq!(shell_quote("$HOME/bin"), "\"$HOME/bin\"");
+    // Non-literal (double-quoted/unquoted source) keeps $ unescaped for expansion.
+    assert_eq!(shell_quote("$HOME/bin", false), "\"$HOME/bin\"");
+}
+
+#[test]
+fn given_value_with_embedded_quote_when_shell_quoting_then_wraps() {
+    assert_eq!(shell_quote("say \"hello\"", false), "\"say \"hello\"\"");
 }
 
 #[test]
 fn given_value_with_backtick_when_shell_quoting_then_wraps() {
-    assert_eq!(shell_quote("echo `date`"), "\"echo `date`\"");
+    assert_eq!(shell_quote("echo `date`", false), "\"echo `date`\"");
 }
 
 #[test]
 fn given_value_with_single_quote_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("it's"), "\"it's\"");
+    assert_eq!(shell_quote("it's", false), "\"it's\"");
 }
 
 #[test]
 fn given_value_with_backslash_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("path\\to"), "\"path\\to\"");
+    assert_eq!(shell_quote("path\\to", false), "\"path\\to\"");
 }
 
 #[test]
 fn given_value_with_semicolon_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("cmd;cmd2"), "\"cmd;cmd2\"");
+    assert_eq!(shell_quote("cmd;cmd2", false), "\"cmd;cmd2\"");
 }
 
 #[test]
 fn given_value_with_pipe_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("a|b"), "\"a|b\"");
+    assert_eq!(shell_quote("a|b", false), "\"a|b\"");
 }
 
 #[test]
 fn given_value_with_ampersand_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("a&b"), "\"a&b\"");
+    assert_eq!(shell_quote("a&b", false), "\"a&b\"");
 }
 
 #[test]
 fn given_value_with_parentheses_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("(group)"), "\"(group)\"");
+    assert_eq!(shell_quote("(group)", false), "\"(group)\"");
 }
 
 #[test]
 fn given_value_with_angle_brackets_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("a<b>c"), "\"a<b>c\"");
+    assert_eq!(shell_quote("a<b>c", false), "\"a<b>c\"");
 }
 
 #[test]
 fn given_value_with_tab_when_shell_quoting_then_adds_quotes() {
-    assert_eq!(shell_quote("a\tb"), "\"a\tb\"");
-}
-
-#[test]
-fn given_numeric_value_when_shell_quoting_then_no_quotes() {
-    assert_eq!(shell_quote("12345"), "12345");
-}
-
-#[test]
-fn given_path_without_special_chars_when_shell_quoting_then_no_quotes() {
-    assert_eq!(shell_quote("/usr/local/bin"), "/usr/local/bin");
+    assert_eq!(shell_quote("a\tb", false), "\"a\tb\"");
 }
 
 #[test]
 fn given_flag_without_spaces_when_shell_quoting_then_no_quotes() {
-    assert_eq!(shell_quote("--verbose"), "--verbose");
+    assert_eq!(shell_quote("--verbose", false), "--verbose");
+}
+
+#[test]
+fn given_numeric_value_when_shell_quoting_then_no_quotes() {
+    assert_eq!(shell_quote("12345", false), "12345");
+}
+
+#[test]
+fn given_path_without_special_chars_when_shell_quoting_then_no_quotes() {
+    assert_eq!(shell_quote("/usr/local/bin", false), "/usr/local/bin");
 }
 
 #[test]
 fn given_alphanumeric_with_hyphens_when_shell_quoting_then_no_quotes() {
-    assert_eq!(shell_quote("my-app-v2.0"), "my-app-v2.0");
+    assert_eq!(shell_quote("my-app-v2.0", false), "my-app-v2.0");
+}
+
+// --- shell_quote tests (literal mode: literal = true) ---
+// literal = true is used for values that were single-quoted in the source.
+// Output must be a POSIX single-quoted literal so the shell performs NO
+// expansion or command substitution when the .envrc is sourced.
+
+#[test]
+fn given_literal_value_with_dollar_when_shell_quoting_then_single_quotes_no_expansion() {
+    // Regression: a password containing $ must survive sourcing verbatim.
+    assert_eq!(
+        shell_quote("0$s7-e|ZKi~dMz3eYqH_6UFE(N-.", true),
+        "'0$s7-e|ZKi~dMz3eYqH_6UFE(N-.'"
+    );
+}
+
+#[test]
+fn given_literal_value_with_backtick_when_shell_quoting_then_single_quotes_no_substitution() {
+    // Backticks inside single quotes are literal - no command substitution.
+    assert_eq!(shell_quote("echo `date`", true), "'echo `date`'");
+}
+
+#[test]
+fn given_literal_value_with_embedded_single_quote_when_shell_quoting_then_escapes() {
+    // POSIX idiom: close quote, escaped quote, reopen quote.
+    assert_eq!(shell_quote("it's", true), "'it'\\''s'");
+}
+
+#[test]
+fn given_literal_empty_value_when_shell_quoting_then_single_quotes() {
+    assert_eq!(shell_quote("", true), "''");
+}
+
+#[test]
+fn given_literal_simple_value_when_shell_quoting_then_no_quotes() {
+    // No special characters - bare output is already literal.
+    assert_eq!(shell_quote("simple", true), "simple");
+}
+
+// --- parse quote-style intent tests ---
+
+#[test]
+fn given_single_quoted_value_when_parsing_then_marks_key_literal() {
+    let content = "export PW='a$b'\n";
+    let env_file = EnvFile::parse(content, PathBuf::from("/project/local.env")).unwrap();
+    assert_eq!(env_file.variables.get("PW"), Some(&"a$b".to_string()));
+    assert!(env_file.literal_keys.contains("PW"));
+}
+
+#[test]
+fn given_double_quoted_value_when_parsing_then_key_not_literal() {
+    let content = "export P=\"$HOME/bin\"\n";
+    let env_file = EnvFile::parse(content, PathBuf::from("/project/local.env")).unwrap();
+    assert!(!env_file.literal_keys.contains("P"));
+}
+
+#[test]
+fn given_unquoted_value_when_parsing_then_key_not_literal() {
+    let content = "export P=plain\n";
+    let env_file = EnvFile::parse(content, PathBuf::from("/project/local.env")).unwrap();
+    assert!(!env_file.literal_keys.contains("P"));
 }

--- a/rsenv/tests/environment_service_test.rs
+++ b/rsenv/tests/environment_service_test.rs
@@ -38,6 +38,62 @@ export BAZ=qux
 }
 
 #[test]
+fn given_single_quoted_value_when_building_then_marks_key_literal() {
+    // Arrange
+    let temp = TempDir::new().unwrap();
+    let leaf = create_env_file(&temp, "local.env", "export PW='a$b'\n");
+    let service = EnvironmentService::new(std::sync::Arc::new(RealFileSystem));
+
+    // Act
+    let result = service.build(&leaf).unwrap();
+
+    // Assert - single-quoted source is preserved as a literal key
+    assert_eq!(result.variables.get("PW"), Some(&"a$b".to_string()));
+    assert!(result.literal_keys.contains("PW"));
+}
+
+#[test]
+fn given_child_double_quotes_a_parent_literal_when_building_then_child_style_wins() {
+    // Arrange - parent declares KEY single-quoted (literal), child redeclares it
+    // double-quoted (expansion). Child override must also override the quote style.
+    let temp = TempDir::new().unwrap();
+    let _base = create_env_file(&temp, "base.env", "export KEY='from_base'\n");
+    let leaf = create_env_file(
+        &temp,
+        "local.env",
+        "# rsenv: base.env\nexport KEY=\"from_local\"\n",
+    );
+    let service = EnvironmentService::new(std::sync::Arc::new(RealFileSystem));
+
+    // Act
+    let result = service.build(&leaf).unwrap();
+
+    // Assert - child wins on value AND on quote style (no longer literal)
+    assert_eq!(result.variables.get("KEY"), Some(&"from_local".to_string()));
+    assert!(!result.literal_keys.contains("KEY"));
+}
+
+#[test]
+fn given_child_single_quotes_a_parent_expansion_when_building_then_child_style_wins() {
+    // Arrange - reverse direction: parent double-quoted, child single-quoted.
+    let temp = TempDir::new().unwrap();
+    let _base = create_env_file(&temp, "base.env", "export KEY=\"from_base\"\n");
+    let leaf = create_env_file(
+        &temp,
+        "local.env",
+        "# rsenv: base.env\nexport KEY='from_local'\n",
+    );
+    let service = EnvironmentService::new(std::sync::Arc::new(RealFileSystem));
+
+    // Act
+    let result = service.build(&leaf).unwrap();
+
+    // Assert - child wins; KEY is now literal
+    assert_eq!(result.variables.get("KEY"), Some(&"from_local".to_string()));
+    assert!(result.literal_keys.contains("KEY"));
+}
+
+#[test]
 fn given_env_file_with_parent_when_building_then_merges_variables() {
     // Arrange - v1 format uses export prefix
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Problem

Values single-quoted in a source env file were re-emitted in double quotes, so the shell expanded `$`, backticks, etc. when sourcing the generated `.envrc`.

A password like `'0$s7-...'` silently became `0-...` because `$s7` expanded to nothing:

## Root cause

Parsing discarded the quote style (`strip_quotes` treats `'` and `"` identically) and `shell_quote` always wrapped values in double quotes. Writer and reader were asymmetric, so a literal value could not survive a round trip.

## Fix

Track per-variable quote style through the pipeline:

- `EnvFile` / `EnvOutput` carry a `literal_keys` set (keys single-quoted in source).
- Merge applies the same child-overrides-parent precedence to the quote style.
- `shell_quote(value, literal)` emits POSIX single quotes (with `'\''` escaping) for literal values, otherwise the legacy double-quoted path.

## Behavior

| Source value | Emitted as | When sourced |
|---|---|---|
| `export PW='p@$$w0rd'` | `'p@$$w0rd'` (single) | literal, no expansion |
| `export DIR="$HOME/bin"` | `"$HOME/bin"` (double) | `$HOME` expands |
| `export PORT=8080` | `8080` (bare) | literal |

Double-quoted and unquoted values keep the existing expansion behavior. Only single-quoted values change: they now stay literal, matching shell semantics.